### PR TITLE
Support spreading generic types that cannot be reduced down to objects

### DIFF
--- a/src/PropType/index.js
+++ b/src/PropType/index.js
@@ -16,9 +16,14 @@ const renderPropType = (
   }
   if (propType.kind === "spread") {
     const furtherProps = reduceToObj(propType.value);
-    return furtherProps.map(p =>
-      renderPropType(p, { overrides, shouldCollapseProps, components })
-    );
+    if (Array.isArray(furtherProps) && furtherProps.length > 0) {
+      /* Only render the spread contents if they are a non-empty value, otherwise render the
+       * spread itself so we can see the spread of generics and other types that have not been
+       * converted into an object */
+      return furtherProps.map(p =>
+        renderPropType(p, { overrides, shouldCollapseProps, components })
+      );
+    }
   }
 
   let description;
@@ -39,12 +44,12 @@ const renderPropType = (
     return null;
   }
 
-  const name = convert(propType.key);
+  const name = propType.kind === 'spread' ? '...' : convert(propType.key);
   const OverrideComponent = overrides[name];
   const commonProps = {
     components,
     name,
-    key: convert(propType.key),
+    key: name,
     required: !propType.optional,
     type: getKind(propType.value),
     defaultValue: propType.default && convert(propType.default),


### PR DESCRIPTION
This PR introduces the ability to show the spreading of generic types that cannot be reduced down to objects.

The primary motivation for this is to show props that we have extended using [ElementConfig](https://flow.org/en/docs/react/types/#toc-react-elementconfig) in https://bitbucket.org/atlassian/atlaskit-mk-2/pull-requests/3750/nav-130-harden-flow-types/diff.

Currently, they do not display at all as spreads are only shown for generics that can be reduced to objects and `ElementConfig` isn't reducible at the moment.